### PR TITLE
Include typings for 3rd parties

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,9 +28,10 @@
   },
   "homepage": "https://github.com/swimlane/coconspirators#readme",
   "devDependencies": {
-    "tslint": "^4.4.2",
-    "@types/node": "^7.0.5",
     "@types/amqplib": "^0.5.3",
+    "@types/node": "^7.0.5",
+    "@types/shortid": "0.0.29",
+    "tslint": "^4.4.2",
     "tslint-config-swimlane": "^2.0.1",
     "typescript": "^2.1.6"
   },

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
   "devDependencies": {
     "tslint": "^4.4.2",
     "@types/node": "^7.0.5",
+    "@types/amqplib": "^0.5.3",
     "tslint-config-swimlane": "^2.0.1",
     "typescript": "^2.1.6"
   },


### PR DESCRIPTION
Typings were missing for shortid and amqplib - I've gone ahead and added these