### PR TITLE
Switch connection.close to use promise api vs callback

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -50,7 +50,7 @@ export class AmqpClient extends EventEmitter {
           });
 
           process.on('SIGINT', () => {
-            connection.close(() => {
+            connection.close().then(() => {
               this.emit('disconnected');
               process.exit(0);
             });


### PR DESCRIPTION
As the promise api for amqplib is being used, the close function returns a promise instead of taking a callback.
If the callback method is desired, you'd need to `import * as amqp from 'amqplib/callback_api`